### PR TITLE
fix: infinite loop when polling location data

### DIFF
--- a/src/screens/distance.tsx
+++ b/src/screens/distance.tsx
@@ -1,5 +1,5 @@
 import { LocationObject } from 'expo-location';
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { FlatList } from 'react-native';
 
 import { Box, Button, Paragraph, Title } from '../providers/theme';
@@ -34,11 +34,17 @@ export const DistanceScreen: React.FC = () => {
 const DistanceLocationList: React.FC<{ locations: LocationObject[] }> = (props) => {
   const listRef = useRef<FlatList<LocationObject>>(null);
 
+  useEffect(() => {
+    // don't ask... if we call it directly,
+    // the list scrolls to the "previous" end instead of the "new" end
+    setTimeout(() => listRef.current?.scrollToEnd())
+  }, [props.locations.length]);
+
   return (
     <Box>
       <FlatList
-        style={{ flexGrow: 0, flexBasis: 200 }}
         ref={listRef}
+        style={{ flexGrow: 0, flexBasis: 200 }}
         data={props.locations}
         keyExtractor={(location, index) => `${location.timestamp}-${index}`}
         renderItem={entry => (
@@ -47,8 +53,6 @@ const DistanceLocationList: React.FC<{ locations: LocationObject[] }> = (props) 
             location={entry.item}
           />
         )}
-        // keep scrolling to bottom when new data is displayed
-        onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: true })}
       />
     </Box>
   );
@@ -56,7 +60,7 @@ const DistanceLocationList: React.FC<{ locations: LocationObject[] }> = (props) 
 
 const DistanceLocation: React.FC<{ number: number, location: LocationObject }> = (props) => (
   <Box variant='row'>
-    <Paragraph>#{props.number}</Paragraph>
+    <Paragraph>#{props.number + 1}</Paragraph>
     <Paragraph>lat: {props.location.coords.latitude}</Paragraph>
     <Paragraph>lng: {props.location.coords.longitude}</Paragraph>
   </Box>

--- a/src/services/location/index.ts
+++ b/src/services/location/index.ts
@@ -1,5 +1,5 @@
 import { LocationObject } from 'expo-location';
-import { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import * as Storage from './storage';
 import * as Track from './track';

--- a/src/services/location/index.ts
+++ b/src/services/location/index.ts
@@ -1,5 +1,5 @@
 import { LocationObject } from 'expo-location';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import * as Storage from './storage';
 import * as Track from './track';
@@ -70,25 +70,30 @@ export function useLocationTracking() {
  * A hook to poll for changes in the storage, updates the UI if locations were added.
  */
 export function useLocationData(interval = 5000) {
-  const [locations, setLocations] = useState<LocationObject[]>([]);
+  const locations = useRef<LocationObject[]>([]);
+  const [count, setCount] = useState(0); // count state is only used as rerender trigger, from timer callback
 
-  const onPollStorage = useCallback(async () => {
-    const stored = await Storage.getLocations();
-    if (stored.length !== locations.length) {
-      setLocations(stored);
+  const onLocations = useCallback((stored: LocationObject[]) => {
+    // check if data was changed using ref data.
+    // this method is called from outside react, so we can't use state data without reinitializing it
+    if (stored.length !== locations.current.length) {
+      // update the locations, but this won't trigger a rerender or update
+      locations.current = stored;
+      // update the state value, triggering a rerender
+      setCount(locations.current.length);
     }
-  }, [locations]);
+  }, [setCount, locations]);
 
   useEffect(() => {
     // load the locations on first render
-    Storage.getLocations().then(setLocations);
+    Storage.getLocations().then(onLocations);
     // create a timer to poll for changes
-    const timerId = window.setInterval(onPollStorage, interval);
+    const timerId = window.setInterval(() => Storage.getLocations().then(onLocations), interval);
     // when the hook is unmounted, remove the timer
     return () => window.clearInterval(timerId);
-  }, [interval, onPollStorage]);
+  }, [interval]);
 
-  return locations;
+  return locations.current;
 }
 
 /**

--- a/src/services/location/index.ts
+++ b/src/services/location/index.ts
@@ -69,7 +69,7 @@ export function useLocationTracking() {
 /**
  * A hook to poll for changes in the storage, updates the UI if locations were added.
  */
-export function useLocationData(interval = 5000) {
+export function useLocationData(interval = 3000) {
   const locations = useRef<LocationObject[]>([]);
   const [count, setCount] = useState(0); // count state is only used as rerender trigger, from timer callback
 


### PR DESCRIPTION
### Linked issue
Fixes #2 

### Additional context
This uses a workaround with `useRef` data to access it within a timer (`setInterval`). This allows us to access the (previous) location data without reinitializing the timer.
