### PR TITLE
Adds message to user and does not allow them 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ npm-debug.*
 *.mobileprovision
 *.orig.*
 web-build/
+*.code-workspace
 
 # macOS
 .DS_Store

--- a/src/screens/distance.tsx
+++ b/src/screens/distance.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useRef } from 'react';
 import { FlatList } from 'react-native';
 
 import { Box, Button, Paragraph, Title } from '../providers/theme';
-import { useLocationData, useLocationDistance, useLocationTracking } from '../services/location'; 
 
 export const DistanceScreen: React.FC = () => {
   const locations = useLocationData();

--- a/src/screens/distance.tsx
+++ b/src/screens/distance.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef } from 'react';
 import { FlatList } from 'react-native';
 
 import { Box, Button, Paragraph, Title } from '../providers/theme';
+import { useLocationData, useLocationDistance, useLocationTracking } from '../services/location';
 
 export const DistanceScreen: React.FC = () => {
   const locations = useLocationData();

--- a/src/screens/distance.tsx
+++ b/src/screens/distance.tsx
@@ -1,6 +1,7 @@
 import { LocationObject } from 'expo-location';
 import React, { useEffect, useRef } from 'react';
 import { FlatList } from 'react-native';
+import { LOCATION, usePermissions } from 'expo-permissions';
 
 import { Box, Button, Paragraph, Title } from '../providers/theme';
 import { useLocationData, useLocationDistance, useLocationTracking } from '../services/location';
@@ -9,6 +10,8 @@ export const DistanceScreen: React.FC = () => {
   const locations = useLocationData();
   const tracking = useLocationTracking();
   const distance = useLocationDistance(locations);
+
+  const permission = usePermissions(LOCATION);
 
   return (
     <Box variant='page'>

--- a/src/screens/distance.tsx
+++ b/src/screens/distance.tsx
@@ -1,17 +1,14 @@
 import { LocationObject } from 'expo-location';
 import React, { useEffect, useRef } from 'react';
 import { FlatList } from 'react-native';
-import { LOCATION, usePermissions } from 'expo-permissions';
 
 import { Box, Button, Paragraph, Title } from '../providers/theme';
-import { useLocationData, useLocationDistance, useLocationTracking } from '../services/location';
+import { useLocationData, useLocationDistance, useLocationTracking } from '../services/location'; 
 
 export const DistanceScreen: React.FC = () => {
   const locations = useLocationData();
   const tracking = useLocationTracking();
   const distance = useLocationDistance(locations);
-
-  const permission = usePermissions(LOCATION);
 
   return (
     <Box variant='page'>

--- a/src/screens/onboarding.tsx
+++ b/src/screens/onboarding.tsx
@@ -8,6 +8,8 @@ export const OnboardingScreen: React.FC = () => {
   const navigation = useNavigation();
   const [permission, askPermission] = usePermissions(LOCATION);
 
+  const permScopeAlways = permission?.permissions.location.scope == "always"; 
+
   const onContinue = useCallback(() => {
     navigation.navigate('Distance');
   }, [navigation]);
@@ -15,12 +17,12 @@ export const OnboardingScreen: React.FC = () => {
   useEffect(() => {
     // Only redirect on first render or permission change,
     // not when users go back to this screen.
-    if (permission?.granted) {
+    if (permission?.granted && permScopeAlways) {
       onContinue();
     }
-  }, [permission?.granted]);
+  }, [permission?.granted, permScopeAlways]);
 
-  if (permission?.granted) {
+  if (permission?.granted && permScopeAlways) {
     return (
       <Box variant='page'>
         <Box>
@@ -36,12 +38,16 @@ export const OnboardingScreen: React.FC = () => {
     <Box variant='page'>
       <Box>
         <Title>We need your permission</Title>
-        <Paragraph>To monitor your office marathon, we need access to background location.</Paragraph>
+        <Paragraph>To monitor your office marathon, we need access to background location. Please select ALWAYS ALLOW location services in your settings.</Paragraph>
       </Box>
       {!permission
         ? <Spinner />
         : <Button onPress={askPermission}>Grant permission</Button>
       }
+      
+      {permission?.granted && !permScopeAlways &&
+          <Paragraph>You have only granted permission to use your location when the app is in use. Please ALWAYS ALLOW location services in your settings.</Paragraph>
+        }
     </Box>
   );
 };

--- a/src/services/location/index.ts
+++ b/src/services/location/index.ts
@@ -36,10 +36,11 @@ function getDistanceFromLocations(locations: LocationObject[]) {
  */
 export function useLocationTracking() {
   const [isTracking, setIsTracking] = useState<boolean>();
+  // const [isBackground, setIsBackground] = useState<boolean>(true);
 
   const onStartTracking = useCallback(async () => {
-    await Track.startTracking();
-    setIsTracking(true);
+      await Track.startTracking();
+      setIsTracking(true);
   }, []);
 
   const onStopTracking = useCallback(async () => {
@@ -60,6 +61,7 @@ export function useLocationTracking() {
 
   return {
     isTracking,
+    // isBackground,
     startTracking: onStartTracking,
     stopTracking: onStopTracking,
     clearTracking: onClearTracking,

--- a/src/services/location/track.ts
+++ b/src/services/location/track.ts
@@ -3,6 +3,7 @@ import * as Location from 'expo-location';
 
 import { addLocation, getLocations } from './storage';
 
+
 /**
  * The unique name of the background location task.
  */
@@ -13,7 +14,7 @@ export const locationTaskName = 'office-marathon';
  * This is a wrapper around `Location.hasStartedLocationUpdatesAsync` with the task name prefilled.
  */
 export async function isTracking(): Promise<boolean> {
-  return await Location.hasStartedLocationUpdatesAsync(locationTaskName);
+    return await Location.hasStartedLocationUpdatesAsync(locationTaskName);
 }
 
 /**
@@ -67,3 +68,4 @@ TaskManager.defineTask(locationTaskName, async (event) => {
     console.log('[tracking]', 'Something went wrong when saving a new location...', error);
   }
 });
+


### PR DESCRIPTION
### Linked issue
Fixes Issue #10 

### Additional context
This fix does not allow the user to continue from the permissions page unless they have allowed background location access.  If they select "when in use" for location permissions, they will no longer be sent to the next page. Previously, they would have been able to get to the "tracking" page, then they would have had no warning telling them why the tracking was not working. 
