### PR TITLE
refactor: drop react fc types

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,10 +4,12 @@ import { AssetProvider } from './providers/asset';
 import { NavigationProvider } from './providers/navigation';
 import { ThemeProvider } from './providers/theme';
 
-export const App: React.FC = () => (
-  <AssetProvider>
-    <ThemeProvider>
-      <NavigationProvider />
-    </ThemeProvider>
-  </AssetProvider>
-);
+export function App() {
+  return (
+    <AssetProvider>
+      <ThemeProvider>
+        <NavigationProvider />
+      </ThemeProvider>
+    </AssetProvider>
+  );
+}

--- a/src/providers/asset.tsx
+++ b/src/providers/asset.tsx
@@ -1,14 +1,14 @@
 import { useFonts, OpenSans_600SemiBold, OpenSans_400Regular } from '@expo-google-fonts/open-sans';
 import AppLoading from 'expo-app-loading';
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 
-export const AssetProvider: React.FC = (props) => {
+export function AssetProvider({ children }: PropsWithChildren<{}>) {
   const [isLoaded] = useFonts({
     'open-sans-regular': OpenSans_400Regular,
     'open-sans-semibold': OpenSans_600SemiBold,
   });
 
   return isLoaded
-    ? <>{props.children}</>
+    ? <>{children}</>
     : <AppLoading />;
-};
+}

--- a/src/providers/navigation.tsx
+++ b/src/providers/navigation.tsx
@@ -12,11 +12,13 @@ export type StackParamList = {
 
 const Stack = createStackNavigator<StackParamList>();
 
-export const NavigationProvider: React.FC = () => (
-  <NavigationContainer>
-    <Stack.Navigator initialRouteName="Onboarding" screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="Onboarding" component={OnboardingScreen} />
-      <Stack.Screen name="Distance" component={DistanceScreen} />
-    </Stack.Navigator>
-  </NavigationContainer>
-);
+export function NavigationProvider() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Onboarding" screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+        <Stack.Screen name="Distance" component={DistanceScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/src/providers/theme.tsx
+++ b/src/providers/theme.tsx
@@ -1,6 +1,6 @@
 import { ActivityIndicator, createThemedComponent, DripsyProvider, makeTheme, useDripsyTheme } from 'dripsy';
 import Constants from 'expo-constants';
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { Pressable, Text, View } from 'react-native';
 
 const theme = makeTheme({
@@ -94,20 +94,23 @@ interface ButtonProps {
 const ButtonPressable = createThemedComponent(Pressable, { themeKey: 'buttons', defaultVariant: 'primary' });
 const ButtonText = createThemedComponent(Text, { themeKey: 'buttons', defaultVariant: 'primary-text' });
 
-export const Button: React.FC<ButtonProps> = (props) => (
-  <ButtonPressable
-    disabled={props.disabled}
-    onPress={props.onPress}
-    accessibilityRole="button"
-  >
-    <Box variant="center">
-      <ButtonText variant={`${props.variant}-text`}>
-        {props.children}
-      </ButtonText>
-    </Box>
-  </ButtonPressable>
-);
+export function Button({ disabled, onPress, variant, children }: PropsWithChildren<ButtonProps>) {
+  return (
+    <ButtonPressable
+      accessibilityRole="button"
+      disabled={disabled}
+      onPress={onPress}
+      variant={variant}
+    >
+      <Box variant="center">
+        <ButtonText variant={`${variant}-text`}>
+          {children}
+        </ButtonText>
+      </Box>
+    </ButtonPressable>
+  );
+}
 
-export const Spinner: React.FC = () => (
-  <ActivityIndicator color="accent" />
-);
+export function Spinner() {
+  return <ActivityIndicator color="accent" />;
+}

--- a/src/screens/distance.tsx
+++ b/src/screens/distance.tsx
@@ -5,7 +5,7 @@ import { FlatList } from 'react-native';
 import { Box, Button, Paragraph, Title } from '../providers/theme';
 import { useLocationData, useLocationDistance, useLocationTracking } from '../services/location';
 
-export const DistanceScreen: React.FC = () => {
+export function DistanceScreen() {
   const locations = useLocationData();
   const tracking = useLocationTracking();
   const distance = useLocationDistance(locations);
@@ -29,23 +29,23 @@ export const DistanceScreen: React.FC = () => {
       <DistanceLocationList locations={locations} />
     </Box>
   );
-};
+}
 
-const DistanceLocationList: React.FC<{ locations: LocationObject[] }> = (props) => {
+function DistanceLocationList({ locations }: { locations: LocationObject[] }) {
   const listRef = useRef<FlatList<LocationObject>>(null);
 
   useEffect(() => {
     // don't ask... if we call it directly,
     // the list scrolls to the "previous" end instead of the "new" end
     setTimeout(() => listRef.current?.scrollToEnd())
-  }, [props.locations.length]);
+  }, [locations.length]);
 
   return (
     <Box>
       <FlatList
         ref={listRef}
         style={{ flexGrow: 0, flexBasis: 200 }}
-        data={props.locations}
+        data={locations}
         keyExtractor={(location, index) => `${location.timestamp}-${index}`}
         renderItem={entry => (
           <DistanceLocation
@@ -56,12 +56,14 @@ const DistanceLocationList: React.FC<{ locations: LocationObject[] }> = (props) 
       />
     </Box>
   );
-};
+}
 
-const DistanceLocation: React.FC<{ number: number, location: LocationObject }> = (props) => (
-  <Box variant='row'>
-    <Paragraph>#{props.number + 1}</Paragraph>
-    <Paragraph>lat: {props.location.coords.latitude}</Paragraph>
-    <Paragraph>lng: {props.location.coords.longitude}</Paragraph>
-  </Box>
-);
+function DistanceLocation({ number, location }: { number: number, location: LocationObject }) {
+  return (
+    <Box variant='row'>
+      <Paragraph>#{number + 1}</Paragraph>
+      <Paragraph>lat: {location.coords.latitude}</Paragraph>
+      <Paragraph>lng: {location.coords.longitude}</Paragraph>
+    </Box>
+  );
+}

--- a/src/screens/onboarding.tsx
+++ b/src/screens/onboarding.tsx
@@ -7,7 +7,7 @@ import { Box, Button, Spinner, Title, Paragraph } from '../providers/theme';
 
 type OnboardingScreenProps = StackScreenProps<StackParamList, 'Onboarding'>;
 
-export const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ navigation }) => {
+export function OnboardingScreen({ navigation }: OnboardingScreenProps) {
   const [permission, askPermission] = useForegroundPermissions();
 
   const onContinue = useCallback(() => {
@@ -46,4 +46,4 @@ export const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ navigation }
       }
     </Box>
   );
-};
+}


### PR DESCRIPTION
### Linked issue
Drop them in favor of simple function components + `PropsWithChildren` generics.

